### PR TITLE
Fix error when running setup.py build due to wrong extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ media_patterns = ( build_media_pattern("templates", "html") +
                    build_media_pattern("static", "png") +
                    build_media_pattern("static", "jpeg") +
                    build_media_pattern("static", "gif") +
-                   build_media_pattern("", "rst")
+                   build_media_pattern("", "md")
 )
 
 package_data = dict(


### PR DESCRIPTION
   error: can't copy 'stopforumspam/README.rst': doesn't exist or not a regular file
