### PR TITLE
Add a option to use the module behind a proxy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ To only include some URLS (only works if SFS_ALL_POST_REQUEST=False):
 
     SFS_URLS_INCLUDE = ["url_name", "/url/path"]
 
+If your application is behind a set of proxy, you can use a specific HTTP Header as a source of the client IP:
+
+    SFS_HTTP_HEADER = "X-Forwarded-For"
+
 ### Synching with stopforumspam.com
 
 Be nice to their servers and remember that they have strict enforcements on the files that they offer. So before

--- a/stopforumspam/middleware.py
+++ b/stopforumspam/middleware.py
@@ -32,8 +32,8 @@ class StopForumSpamMiddleware():
             return self.check_request_ip(request)
     
     def check_request_ip(self, request):
-        
-        remote_ip = ipv6._unpack_ipv4(request.META['REMOTE_ADDR'])
+
+        remote_ip = ipv6._unpack_ipv4(request.META[sfs_settings.HEADER])
         
         cache_entries = models.Cache.objects.filter(ip=remote_ip)
         

--- a/stopforumspam/settings.py
+++ b/stopforumspam/settings.py
@@ -24,3 +24,7 @@ ZIP_FILENAME = getattr(settings, 'SFS_ZIP_FILENAME', "listed_ip_7.txt")
 FORCE_ALL_REQUESTS = getattr(settings, 'SFS_FORCE_ALL_REQUESTS', False)
 
 LOG_SPAM = getattr(settings, 'SFS_LOG_SPAM', True)
+
+HEADER = getattr(settings, 'SFS_HTTP_HEADER', 'REMOTE_ADDR')
+if HEADER != 'REMOTE_ADDR':
+    HEADER = 'HTTP_' + HEADER.upper().replace('-','_')


### PR DESCRIPTION
Some people host their Django applications beyond a set of proxies, which
mean that REMOTE_ADDR is the ip address of the proxies, not of the client.
Most of them usually place the original IP address in a different HTTP header,
so making this configurable make stopforumspam work in such a environment.
