### PR TITLE
updated django version requirement to 1.4 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(name='stopforumspam',
       packages=packages,
       license='BSD License',
       install_requires=[
-        'Django>=1.3.0',
+        'Django>=1.4.0',
       ],
       url='https://overtag.dk/',
       classifiers=CLASSIFIERS,


### PR DESCRIPTION
ipv6 needed in the middleware is only available in django 1.4
