### PR TITLE
Django 2.0 compatibility

### DIFF
--- a/stopforumspam/middleware.py
+++ b/stopforumspam/middleware.py
@@ -1,12 +1,13 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import render
 from django.utils import ipv6
+from django.utils.deprecation import MiddlewareMixin
 
 from . import settings as sfs_settings
 from . import models
 
 
-class StopForumSpamMiddleware():
+class StopForumSpamMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
 


### PR DESCRIPTION
Django 2.0 dropped the compatibility for 'old-style' middlewares.
Thankfully, they provide a mixin for easing the migration.  See:

https://docs.djangoproject.com/en/2.0/topics/http/middleware/#upgrading-middleware

This patch makes the stopforumspam compatibly with Django 2.0.

This may warrant a bump to 2.0, as that patch requires at least Django 1.10 for the mixin and the change to `django.urls`.  I'll let you judge.